### PR TITLE
Fix regex literals in rewriteRussia

### DIFF
--- a/content.js
+++ b/content.js
@@ -43,8 +43,8 @@
 
   function rewriteRussia() {
     document.body.innerHTML = document.body.innerHTML
-      .replace(/Russia/g, "russia")
-      .replace(/RUSSIA/g, "rUSSIA");
+      .replace(/Russia/g, "russia")
+      .replace(/RUSSIA/g, "rUSSIA");
   }
 
   function scrub() {
@@ -57,3 +57,4 @@
   const observer = new MutationObserver(scrub);
   observer.observe(document.body, { childList: true, subtree: true });
 })();
+


### PR DESCRIPTION
## Summary
- update `rewriteRussia` to use proper regex literals

## Testing
- `node -e "require('./content.js')"` *(fails: chrome is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6843daa4d5bc832eb33cedf4976cfb0e